### PR TITLE
Replace `serde_nbt` with `valence_nbt` in the benchmarks

### DIFF
--- a/crates/graphite_binary/Cargo.toml
+++ b/crates/graphite_binary/Cargo.toml
@@ -18,7 +18,7 @@ graphite_binary_macros = { path = "macros", version = "0.1.0" }
 criterion = "0.3.6"
 hematite-nbt = "0.5.2"
 quartz_nbt = "0.2.6"
-serde_nbt = "0.1.0"
+valence_nbt = "0.1.0"
 rand = "0.8.5"
 
 [[bench]]


### PR DESCRIPTION
`valence_nbt` supersedes `serde_nbt`.

Results from my computer

```
graphite_parse_bigtest  time:   [1.6939 µs]
valence_parse_bigtest   time:   [2.7973 µs]
quartz_parse_bigtest    time:   [3.5792 µs]

graphite_write_bigtest  time:   [493.81 ns]
valence_write_bigtest   time:   [970.85 ns]
quartz_write_bigtest    time:   [929.17 ns]

graphite_find_bigtest   time:   [23.825 ns]
valence_find_bigtest    time:   [59.474 ns]
quartz_find_bigtest     time:   [50.074 ns]
```