### PR TITLE
Bump valence_nbt version in benchmarks

### DIFF
--- a/crates/graphite_binary/Cargo.toml
+++ b/crates/graphite_binary/Cargo.toml
@@ -19,7 +19,7 @@ graphite_binary_macros = { path = "macros", version = "0.1.0" }
 criterion = "0.3.6"
 hematite-nbt = "0.5.2"
 quartz_nbt = "0.2.6"
-valence_nbt = "0.1.0"
+valence_nbt = "0.2.0"
 rand = "0.8.5"
 
 [[bench]]


### PR DESCRIPTION
Turns out that `BTreeMap`s can be a bit faster than `HashMap`s when the element count is low.